### PR TITLE
fix: legacy and aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ RUN <<EOF
     pm-utils \
     qemu-block-extra \
     qemu-efi \
-    qemu-kvm
+    qemu-kvm \
+    seabios
   apt-get clean
   rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
Add `seabios` for better support of variety of configurations and platforms.

Prevent errors like:

```
libvirt.libvirtError: internal error: qemu unexpectedly closed the monitor: 2023-08-30T15:08:26.002735Z qemu-system-aarch64: -device virtio-vga,id=video
0,max_outputs=1,bus=pci.6,addr=0x0: failed to find romfile "vgabios-virtio.bin"
```
