### PR TITLE
add mdevctl package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -qq && \
         libtpms0 \
         libvirt-clients \
         libvirt-daemon-system \
+        mdevctl \
         openssh-client \
         openvswitch-switch \
         ovmf \


### PR DESCRIPTION
Logs from user obtained when getting the vGPU feature:
```2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [None
req-4b49642f-487b-49f1-9cbf-2820335ed5aa
cd4181ee6d364b4ca101fe66e621ecdc c47aa9f48e884557b046b53c8f90b192 - -
814091ac781b42fe8daa233432d561ab 814091ac781b42fe8daa233432d561ab]
[instance: 5d225309-1b68-4033-bead-ac163798f6a6] Failed to build and run
instance: libvirt.libvirtError: Cannot find 'mdevctl' in path: No such
file or directory
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6] Traceback (most recent call last):
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/compute/manager.py",
line 2642, in _build_and_run_instance
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]  self.driver.spawn(context,
instance, image_meta,
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py",
line 4743, in spawn
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     mdevs =
self._allocate_mdevs(allocations)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/oslo_concurrency/lockutils.py",
line 412, in inner
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     return f(*args, **kwargs)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py",
line 9019, in _allocate_mdevs
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     chosen_mdev =
self._create_new_mediated_device(parent_device)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py",
line 8926, in _create_new_mediated_device
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     chosen_mdev = self._create_mdev(
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py",
line 8876, in _create_mdev
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]  self._host.device_create(conf)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/host.py",
line 1267, in device_create
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     return
self.get_connection().nodeDeviceCreateXML(device_xml, flags=0)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/eventlet/tpool.py",
line 186, in doit
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     result =
proxy_call(self._autowrap, f, *args, **kwargs)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/eventlet/tpool.py",
line 144, in proxy_call
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     rv = execute(f, *args, **kwargs)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/eventlet/tpool.py",
line 125, in execute
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     raise e.with_traceback(tb)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/var/lib/openstack/lib/python3.10/site-packages/eventlet/tpool.py",
line 82, in tworker
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     rv = meth(*args, **kwargs)
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]   File
"/usr/lib/python3/dist-packages/libvirt.py", line 5045, in
nodeDeviceCreateXML
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6]     raise
libvirtError('virNodeDeviceCreateXML() failed')
2025-12-01 15:28:44.943 119149 ERROR nova.compute.manager [instance:
5d225309-1b68-4033-bead-ac163798f6a6] libvirt.libvirtError: Cannot find
'mdevctl' in path: No such file or directory