### PR TITLE
Bump to stable/2026.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM ghcr.io/vexxhost/ubuntu-cloud-archive:main@sha256:9e5b4bc2ee715df5780a13f44bed013f084e91c9d26dc38d2a7ec7929d41b35b
+FROM ghcr.io/vexxhost/ubuntu-cloud-archive:2026.1@sha256:2e655a7437a95ebb4065b5328e916195e39a79449c8593af015acfc67b2fdfb9
 RUN groupadd -g 42424 nova && \
     useradd -u 42424 -g 42424 -M -d /var/lib/nova -s /usr/sbin/nologin -c "Nova User" nova && \
     mkdir -p /etc/nova /var/log/nova /var/lib/nova /var/cache/nova && \


### PR DESCRIPTION
Automated bump of base image digests and upstream refs to stable/2026.1.

- Dockerfile: ubuntu-cloud-archive: main -> 2026.1