### PR TITLE
fix: install apparmor userspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN groupadd -g 42424 nova && \
     chown -Rv nova:nova /etc/nova /var/log/nova /var/lib/nova /var/cache/nova
 RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
+        apparmor \
         ceph-common \
         cgroup-tools \
         dmidecode \


### PR DESCRIPTION
## Summary

- Install the `apparmor` package in the libvirt image.
- Provide AppArmor userspace support such as `apparmor_parser` and the standard AppArmor include/profile tree inside the container image.

## Why

Libvirt needs AppArmor userspace available inside the libvirt container in order to advertise and use AppArmor security drivers for VM confinement. Without these files in the image, deployments have to borrow parser/support files from the host via extra mounts.

This does not remove the need for the pod to access the host AppArmor kernel interface when libvirt loads profiles, but it reduces the image-side host mount requirements.

## Validation

- Ran `git diff --check`.