### PR TITLE
fix: install apparmor userspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN groupadd -g 42424 nova && \
     chown -Rv nova:nova /etc/nova /var/log/nova /var/lib/nova /var/cache/nova
 RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
+        apparmor \
         ceph-common \
         cgroup-tools \
         dmidecode \


### PR DESCRIPTION
## Summary

- Backport #231 to `stable/2025.2`.
- Install the `apparmor` package in the libvirt image so AppArmor userspace support is available in the container.

## Why

Libvirt needs AppArmor userspace such as `apparmor_parser` and the standard profile/include tree in order to advertise and use AppArmor security drivers for VM confinement. Without these files in the image, deployments need extra host mounts for image-owned AppArmor support files.

## Validation

- Cherry-picked from `c751c7bb66d70ff32ecbdbfd2f6c8515a302af83` with `-x`.
- Ran `git diff --check`.