### PR TITLE
fix: install QEMU compatibility EFI ROMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qq && \
         ebtables \
         iproute2 \
         ipxe-qemu \
+        ipxe-qemu-256k-compat-efi-roms \
         kmod \
         libtpms0 \
         libvirt-clients \


### PR DESCRIPTION
## What changed

Install `ipxe-qemu-256k-compat-efi-roms` explicitly in the libvirtd image.

## Why

Ubuntu QEMU maps older machine types such as `pc-i440fx-2.5` to fixed-size compatibility option ROMs. In particular, `virtio-net-pci` requests `compat-256k-efi-virtio.rom`.

The file is shipped by `ipxe-qemu-256k-compat-efi-roms`, which is only recommended by the QEMU package. Because this image installs packages with `--no-install-recommends`, the ROM package was omitted even though `ipxe-qemu` itself was installed. Guests using those older machine types consequently fail during QEMU startup with `failed to find romfile "compat-256k-efi-virtio.rom"`.

Installing the compatibility package restores support for those machine types and for instances migrated from older Ubuntu/QEMU environments.

## Validation

- `git diff --check`
- Reproduced the failure on the current image with `pc-i440fx-2.5`
- Confirmed newer machine types start without requesting the missing compatibility ROM
- Confirmed the package provides `/usr/lib/ipxe/qemu/compat-256k-efi-virtio.rom`