### PR TITLE
[2026.1] fix: install QEMU compatibility EFI ROMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qq && \
         ebtables \
         iproute2 \
         ipxe-qemu \
+        ipxe-qemu-256k-compat-efi-roms \
         kmod \
         libtpms0 \
         libvirt-clients \


### PR DESCRIPTION
Backport of #260.

Installs `ipxe-qemu-256k-compat-efi-roms` explicitly so older Ubuntu QEMU machine types can load `compat-256k-efi-virtio.rom` when the image is built with `--no-install-recommends`.

Validation:
- clean cherry-pick from merged main commit `4512d1c08a57df3ecce8c720406e1b7d1d8246d4`
- `git diff --check`