### PR TITLE
Preserve legacy AMD SPEC_CTRL guest ABI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,53 @@
+# syntax=docker/dockerfile:1.7
 # SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM ghcr.io/vexxhost/ubuntu-cloud-archive:2025.2@sha256:53692640ab0912161d706797c4807e3d3308b712e40e65e83f5d1d2fbbd464c0
+ARG FROM=ghcr.io/vexxhost/ubuntu-cloud-archive:2025.2@sha256:53692640ab0912161d706797c4807e3d3308b712e40e65e83f5d1d2fbbd464c0
+
+FROM ${FROM} AS qemu-builder
+ARG TARGETARCH
+ARG QEMU_COMMIT=c509d34e5d97b1949b8daafbb53afdd036c2195d
+ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost1
+RUN if [ "${TARGETARCH}" = amd64 ]; then \
+        apt-get update && \
+        apt-get install --no-install-recommends -y \
+            build-essential \
+            devscripts \
+            equivs \
+            git \
+            quilt; \
+    fi
+WORKDIR /src/qemu
+RUN if [ "${TARGETARCH}" = amd64 ]; then \
+        git init && \
+        git remote add origin https://git.launchpad.net/ubuntu/+source/qemu && \
+        git fetch --depth=1 origin ${QEMU_COMMIT} && \
+        git checkout --detach FETCH_HEAD && \
+        mk-build-deps \
+            --build-dep \
+            --install \
+            --remove \
+            --tool 'apt-get -y --no-install-recommends' \
+            debian/control; \
+    fi
+COPY patches/qemu /patches/qemu
+COPY hack/build-qemu /usr/local/bin/build-qemu
+RUN --network=none if [ "${TARGETARCH}" = amd64 ]; then \
+        QEMU_PACKAGE_VERSION=${QEMU_PACKAGE_VERSION} build-qemu; \
+    else \
+        mkdir /out; \
+    fi
+
+FROM ${FROM}
+ARG TARGETARCH
+ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost1
 RUN groupadd -g 42424 nova && \
     useradd -u 42424 -g 42424 -M -d /var/lib/nova -s /usr/sbin/nologin -c "Nova User" nova && \
     mkdir -p /etc/nova /var/log/nova /var/lib/nova /var/cache/nova && \
     chown -Rv nova:nova /etc/nova /var/log/nova /var/lib/nova /var/cache/nova
-RUN apt-get update -qq && \
+RUN --mount=type=bind,from=qemu-builder,source=/out,target=/qemu-debs,ro \
+    if [ "${TARGETARCH}" = amd64 ]; then QEMU_DEBS=/qemu-debs/*.deb; fi && \
+    apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
         apparmor \
         ceph-common \
@@ -30,6 +71,10 @@ RUN apt-get update -qq && \
         qemu-kvm \
         seabios \
         swtpm \
-        swtpm-tools && \
+        swtpm-tools \
+        ${QEMU_DEBS} && \
+    if [ "${TARGETARCH}" = amd64 ]; then \
+        test "$(dpkg-query -W -f='${Version}' qemu-system-x86)" = "${QEMU_PACKAGE_VERSION}"; \
+    fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/hack/build-qemu
+++ b/hack/build-qemu
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: © 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+: "${QEMU_PACKAGE_VERSION:?QEMU_PACKAGE_VERSION must be set}"
+
+export QUILT_PATCHES=debian/patches
+quilt push -a
+
+while read -r patch; do
+    [[ -n "${patch}" && "${patch}" != \#* ]] || continue
+    install -m 0644 "/patches/qemu/${patch}" "debian/patches/${patch}"
+    printf '%s\n' "${patch}" >> debian/patches/series
+done < /patches/qemu/series
+
+QUILT_PATCH_OPTS="--unified -p1" quilt push -a --fuzz=0 --leave-rejects
+
+DEBFULLNAME="VEXXHOST QEMU Maintainers" \
+DEBEMAIL="support@vexxhost.com" \
+dch \
+    --newversion "${QEMU_PACKAGE_VERSION}" \
+    --distribution noble \
+    "Preserve the legacy AMD SPEC_CTRL guest ABI for live migration"
+
+dpkg-buildpackage --build=any --unsigned-source --unsigned-changes -jauto
+
+mkdir -p /out
+find .. -maxdepth 1 -type f \
+    \( -name 'qemu-system-common_*_*.deb' -o \
+       -name 'qemu-system-x86_*_*.deb' \) \
+    -exec cp -v '{}' /out/ ';'
+
+test "$(find /out -maxdepth 1 -type f -name '*.deb' | wc -l)" -eq 2

--- a/patches/qemu/amd-legacy-spec-ctrl.patch
+++ b/patches/qemu/amd-legacy-spec-ctrl.patch
@@ -1,0 +1,166 @@
+Description: preserve the legacy AMD SPEC_CTRL guest ABI
+ Linux 6.13 changed KVM's AMD SPEC_CTRL capability requirements, which makes
+ otherwise identical AMD hosts reject live migration of existing guests.
+ Preserve SPEC_CTRL only when an AMD guest requests it and KVM provides the
+ IA32_SPEC_CTRL MSR, without changing generic x-force-features semantics.
+Author: VEXXHOST, Inc. <support@vexxhost.com>
+Forwarded: not-needed
+Last-Update: 2026-08-28
+
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index a66e5a3..e9eaf6e 100644
+--- a/target/i386/cpu.c
++++ b/target/i386/cpu.c
+@@ -5038,6 +5038,20 @@ static void mark_unavailable_features(X86CPU *cpu, FeatureWord w, uint64_t mask,
+     FeatureWordInfo *f = &feature_word_info[w];
+     int i;
+ 
++#ifdef CONFIG_KVM
++    if (cpu->amd_legacy_spec_ctrl &&
++        kvm_enabled() &&
++        kvm_supports_spec_ctrl_msr() &&
++        IS_AMD_CPU(env) &&
++        w == FEAT_7_0_EDX &&
++        (mask & CPUID_7_0_EDX_SPEC_CTRL)) {
++        mask &= ~CPUID_7_0_EDX_SPEC_CTRL;
++        if (verbose_prefix) {
++            warn_report("preserving legacy AMD SPEC_CTRL guest ABI");
++        }
++    }
++#endif
++
+     if (!cpu->force_features) {
+         env->features[w] &= ~mask;
+     }
+@@ -7864,6 +7878,8 @@ static Property x86_cpu_properties[] = {
+     DEFINE_PROP_BOOL("check", X86CPU, check_cpuid, true),
+     DEFINE_PROP_BOOL("enforce", X86CPU, enforce_cpuid, false),
+     DEFINE_PROP_BOOL("x-force-features", X86CPU, force_features, false),
++    DEFINE_PROP_BOOL("x-amd-legacy-spec-ctrl", X86CPU,
++                     amd_legacy_spec_ctrl, true),
+     DEFINE_PROP_BOOL("kvm", X86CPU, expose_kvm, true),
+     DEFINE_PROP_UINT32("phys-bits", X86CPU, phys_bits, 0),
+     DEFINE_PROP_BOOL("host-phys-bits", X86CPU, host_phys_bits, false),
+diff --git a/target/i386/cpu.h b/target/i386/cpu.h
+index 705d925..7a352c8 100644
+--- a/target/i386/cpu.h
++++ b/target/i386/cpu.h
+@@ -1930,6 +1930,13 @@ struct ArchCPU {
+      * compatibility.
+      */
+     bool force_features;
++    /*
++     * Preserve the legacy AMD SPEC_CTRL guest ABI when KVM provides the
++     * IA32_SPEC_CTRL MSR but no longer advertises CPUID.7.0:EDX[26]. This is
++     * enabled by default in the VEXXHOST downstream build and may be disabled
++     * with x-amd-legacy-spec-ctrl=off.
++     */
++    bool amd_legacy_spec_ctrl;
+     bool expose_kvm;
+     bool expose_tcg;
+     bool migratable;
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index a0bc9ea..558ce36 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -178,6 +178,11 @@ bool kvm_has_exception_payload(void)
+     return has_exception_payload;
+ }
+ 
++bool kvm_supports_spec_ctrl_msr(void)
++{
++    return has_msr_spec_ctrl;
++}
++
+ static bool kvm_x2apic_api_set_flags(uint64_t flags)
+ {
+     KVMState *s = KVM_STATE(current_accel());
+diff --git a/target/i386/kvm/kvm_i386.h b/target/i386/kvm/kvm_i386.h
+index 30fedcf..dbf147a 100644
+--- a/target/i386/kvm/kvm_i386.h
++++ b/target/i386/kvm/kvm_i386.h
+@@ -58,6 +58,7 @@ void kvm_put_apicbase(X86CPU *cpu, uint64_t value);
+ 
+ bool kvm_has_x2apic_api(void);
+ bool kvm_has_waitpkg(void);
++bool kvm_supports_spec_ctrl_msr(void);
+ 
+ uint64_t kvm_swizzle_msi_ext_dest_id(uint64_t address);
+ void kvm_update_msi_routes_all(void *private, bool global,
+diff --git a/tests/avocado/x86_amd_legacy_spec_ctrl.py b/tests/avocado/x86_amd_legacy_spec_ctrl.py
+new file mode 100644
+index 0000000..bc03c94
+--- /dev/null
++++ b/tests/avocado/x86_amd_legacy_spec_ctrl.py
+@@ -0,0 +1,71 @@
++# Validate AMD legacy SPEC_CTRL live-migration compatibility.
++#
++# Copyright (c) 2026 VEXXHOST, Inc.
++#
++# This work is licensed under the terms of the GNU GPL, version 2 or
++# later. See the COPYING file in the top-level directory.
++
++from avocado import skipUnless
++from avocado_qemu import QemuSystemTest
++
++
++class X86CPUFeatureReporting(QemuSystemTest):
++    """:avocado: tags=arch:x86_64"""
++
++    @staticmethod
++    def feature_word(words, eax, ecx, register):
++        for word in words:
++            if (word['cpuid-input-eax'] == eax and
++                    word.get('cpuid-input-ecx', 0) == ecx and
++                    word['cpuid-register'] == register):
++                return word['features']
++        return 0
++
++    def cpu_features(self):
++        cpu_path = self.vm.cmd('query-cpus-fast')[0]['qom-path']
++        present = self.vm.cmd('qom-get', path=cpu_path,
++                              property='feature-words')
++        filtered = self.vm.cmd('qom-get', path=cpu_path,
++                               property='filtered-features')
++        return present, filtered
++
++    def test_force_features_semantics_unchanged(self):
++        """Generic x-force-features still reports unsupported features."""
++        hle_bit = 1 << 4
++
++        self.require_accelerator('tcg')
++        self.vm.add_args('-S', '-accel', 'tcg')
++        self.set_vm_arg('-cpu',
++                        'EPYC-Rome,hle=on,x-force-features=on')
++        self.vm.launch()
++        present, filtered = self.cpu_features()
++
++        self.assertEqual(self.feature_word(present, 7, 0, 'EBX') & hle_bit,
++                         hle_bit)
++        self.assertEqual(self.feature_word(filtered, 7, 0, 'EBX') & hle_bit,
++                         hle_bit)
++
++    @skipUnless('AuthenticAMD' in open('/proc/cpuinfo').read(),
++                'requires an AMD KVM host')
++    def test_amd_legacy_spec_ctrl(self):
++        """The scoped property preserves only AMD SPEC_CTRL reporting.
++
++        :avocado: tags=accel:kvm
++        """
++        spec_ctrl_bit = 1 << 26
++
++        self.require_accelerator('kvm')
++        self.vm.add_args('-S', '-accel', 'kvm')
++        self.set_vm_arg('-cpu', 'EPYC-Rome,spec-ctrl=on')
++        self.vm.launch()
++        cpu_path = self.vm.cmd('query-cpus-fast')[0]['qom-path']
++        self.assertTrue(self.vm.cmd('qom-get', path=cpu_path,
++                                    property='x-amd-legacy-spec-ctrl'))
++        present, filtered = self.cpu_features()
++
++        self.assertEqual(
++            self.feature_word(present, 7, 0, 'EDX') & spec_ctrl_bit,
++            spec_ctrl_bit)
++        self.assertEqual(
++            self.feature_word(filtered, 7, 0, 'EDX') & spec_ctrl_bit,
++            0)

--- a/patches/qemu/series
+++ b/patches/qemu/series
@@ -1,0 +1,1 @@
+amd-legacy-spec-ctrl.patch


### PR DESCRIPTION
## Summary

- rebuild Ubuntu Noble's QEMU `1:8.2.2+ds-0ubuntu1.18` using its native Debian packaging
- add a narrowly scoped downstream compatibility patch for legacy AMD `SPEC_CTRL` guests
- install the generated `qemu-system-common` and `qemu-system-x86` packages without copying `.deb` files into the final image

## Background

Linux 6.13 changed KVM's AMD `SPEC_CTRL` capability requirements. Existing guests created on older kernels can explicitly require `CPUID.7.0:EDX[26]`, while newer destination kernels no longer advertise it. QEMU can retain the CPUID bit and the destination KVM still exposes `IA32_SPEC_CTRL`, but QEMU currently reports the bit as filtered, causing libvirt to abort live migration.

The patch preserves only `SPEC_CTRL` when all of the following are true:

- KVM is active
- the virtual CPU vendor is AMD
- the guest already requests `spec-ctrl`
- KVM exposes `IA32_SPEC_CTRL`
- KVM would otherwise filter the CPUID bit

It does not add `spec-ctrl` to guests that do not request it and does not change generic `x-force-features` behavior.

## Packaging

The builder pins Ubuntu's exact Launchpad import commit for `0ubuntu1.18`, applies Ubuntu's full Quilt series first, then applies the VEXXHOST patch. Build dependencies and packages are handled through:

- `mk-build-deps`
- `quilt`
- `dch`
- `dpkg-buildpackage`

The final stage uses a BuildKit bind mount from the builder output, so package archives are never stored in a final-image layer.

## Validation

- [x] downstream patch applies after Ubuntu's complete `0ubuntu1.18` patch stack with `--fuzz=0`
- [x] QEMU package build completes successfully
- [x] full amd64 `docker-libvirtd` image build completes successfully
- [x] installed versions are consistent:
  - `qemu-system-common 1:8.2.2+ds-0ubuntu1.18+vexxhost1`
  - `qemu-system-x86 1:8.2.2+ds-0ubuntu1.18+vexxhost1`
  - `qemu-block-extra 1:8.2.2+ds-0ubuntu1.18`
  - `qemu-utils 1:8.2.2+ds-0ubuntu1.18`
- [x] QMP reports `x-amd-legacy-spec-ctrl=true`
- [x] generic forced unsupported HLE remains present in `filtered-features`
- [x] existing x86 CPUID qtest suite passes (45/45)
- [x] `IA32_SPEC_CTRL` CPUID/MSR probe returns `1RW`
- [ ] run the disposable YUL1 to YUL2 Nova live-migration canary with the published image
