### PR TITLE
[stable/zed] Preserve legacy AMD SPEC_CTRL guest ABI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,53 @@
+# syntax=docker/dockerfile:1.7
 # SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM ghcr.io/vexxhost/ubuntu-cloud-archive:zed@sha256:ea5b18e1c623af13250f67b9720024c001a5bd4fae6f2eda26d0935fdc70a1f8
+ARG FROM=ghcr.io/vexxhost/ubuntu-cloud-archive:zed@sha256:ea5b18e1c623af13250f67b9720024c001a5bd4fae6f2eda26d0935fdc70a1f8
+
+FROM ${FROM} AS qemu-builder
+ARG TARGETARCH
+ARG QEMU_COMMIT=004a3f40281fbcb896ab96c57359267128140251
+ARG QEMU_PACKAGE_VERSION=1:6.2+dfsg-2ubuntu6.31+vexxhost1
+RUN if [ "${TARGETARCH}" = amd64 ]; then \
+        apt-get update && \
+        apt-get install --no-install-recommends -y \
+            build-essential \
+            devscripts \
+            equivs \
+            git \
+            quilt; \
+    fi
+WORKDIR /src/qemu
+RUN if [ "${TARGETARCH}" = amd64 ]; then \
+        git init && \
+        git remote add origin https://git.launchpad.net/ubuntu/+source/qemu && \
+        git fetch --depth=1 origin ${QEMU_COMMIT} && \
+        git checkout --detach FETCH_HEAD && \
+        mk-build-deps \
+            --build-dep \
+            --install \
+            --remove \
+            --tool 'apt-get -y --no-install-recommends' \
+            debian/control; \
+    fi
+COPY patches/qemu /patches/qemu
+COPY hack/build-qemu /usr/local/bin/build-qemu
+RUN --network=none if [ "${TARGETARCH}" = amd64 ]; then \
+        QEMU_PACKAGE_VERSION=${QEMU_PACKAGE_VERSION} build-qemu; \
+    else \
+        mkdir /out; \
+    fi
+
+FROM ${FROM}
+ARG TARGETARCH
+ARG QEMU_PACKAGE_VERSION=1:6.2+dfsg-2ubuntu6.31+vexxhost1
 RUN groupadd -g 42424 nova && \
     useradd -u 42424 -g 42424 -M -d /var/lib/nova -s /usr/sbin/nologin -c "Nova User" nova && \
     mkdir -p /etc/nova /var/log/nova /var/lib/nova /var/cache/nova && \
     chown -Rv nova:nova /etc/nova /var/log/nova /var/lib/nova /var/cache/nova
-RUN apt-get update -qq && \
+RUN --mount=type=bind,from=qemu-builder,source=/out,target=/qemu-debs,ro \
+    if [ "${TARGETARCH}" = amd64 ]; then QEMU_DEBS=/qemu-debs/*.deb; fi && \
+    apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
         ceph-common \
         cgroup-tools \
@@ -28,6 +69,10 @@ RUN apt-get update -qq && \
         qemu-kvm \
         seabios \
         swtpm \
-        swtpm-tools && \
+        swtpm-tools \
+        ${QEMU_DEBS} && \
+    if [ "${TARGETARCH}" = amd64 ]; then \
+        test "$(dpkg-query -W -f='${Version}' qemu-system-x86)" = "${QEMU_PACKAGE_VERSION}"; \
+    fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/hack/build-qemu
+++ b/hack/build-qemu
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: © 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+: "${QEMU_PACKAGE_VERSION:?QEMU_PACKAGE_VERSION must be set}"
+
+export QUILT_PATCHES=debian/patches
+quilt push -a
+
+while read -r patch; do
+    [[ -n "${patch}" && "${patch}" != \#* ]] || continue
+    install -m 0644 "/patches/qemu/${patch}" "debian/patches/${patch}"
+    printf '%s\n' "${patch}" >> debian/patches/series
+done < /patches/qemu/series
+
+QUILT_PATCH_OPTS="--unified -p1" quilt push -a --fuzz=0 --leave-rejects
+
+DEBFULLNAME="VEXXHOST QEMU Maintainers" \
+DEBEMAIL="support@vexxhost.com" \
+dch \
+    --newversion "${QEMU_PACKAGE_VERSION}" \
+    --distribution noble \
+    "Preserve the legacy AMD SPEC_CTRL guest ABI for live migration"
+
+dpkg-buildpackage --build=any --unsigned-source --unsigned-changes -jauto
+
+mkdir -p /out
+find .. -maxdepth 1 -type f \
+    \( -name 'qemu-system-common_*_*.deb' -o \
+       -name 'qemu-system-x86_*_*.deb' \) \
+    -exec cp -v '{}' /out/ ';'
+
+test "$(find /out -maxdepth 1 -type f -name '*.deb' | wc -l)" -eq 2

--- a/patches/qemu/amd-legacy-spec-ctrl.patch
+++ b/patches/qemu/amd-legacy-spec-ctrl.patch
@@ -1,0 +1,166 @@
+Description: preserve the legacy AMD SPEC_CTRL guest ABI
+ Linux 6.13 changed KVM's AMD SPEC_CTRL capability requirements, which makes
+ otherwise identical AMD hosts reject live migration of existing guests.
+ Preserve SPEC_CTRL only when an AMD guest requests it and KVM provides the
+ IA32_SPEC_CTRL MSR, without changing generic x-force-features semantics.
+Author: VEXXHOST, Inc. <support@vexxhost.com>
+Forwarded: not-needed
+Last-Update: 2026-08-28
+
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index 2643bb7c5..9310e851b 100644
+--- a/target/i386/cpu.c
++++ b/target/i386/cpu.c
+@@ -4521,6 +4521,20 @@ static void mark_unavailable_features(X86CPU *cpu, FeatureWord w, uint64_t mask,
+     FeatureWordInfo *f = &feature_word_info[w];
+     int i;
+ 
++#ifdef CONFIG_KVM
++    if (cpu->amd_legacy_spec_ctrl &&
++        kvm_enabled() &&
++        kvm_supports_spec_ctrl_msr() &&
++        IS_AMD_CPU(env) &&
++        w == FEAT_7_0_EDX &&
++        (mask & CPUID_7_0_EDX_SPEC_CTRL)) {
++        mask &= ~CPUID_7_0_EDX_SPEC_CTRL;
++        if (verbose_prefix) {
++            warn_report("preserving legacy AMD SPEC_CTRL guest ABI");
++        }
++    }
++#endif
++
+     if (!cpu->force_features) {
+         env->features[w] &= ~mask;
+     }
+@@ -7112,6 +7126,8 @@ static Property x86_cpu_properties[] = {
+     DEFINE_PROP_BOOL("check", X86CPU, check_cpuid, true),
+     DEFINE_PROP_BOOL("enforce", X86CPU, enforce_cpuid, false),
+     DEFINE_PROP_BOOL("x-force-features", X86CPU, force_features, false),
++    DEFINE_PROP_BOOL("x-amd-legacy-spec-ctrl", X86CPU,
++                     amd_legacy_spec_ctrl, true),
+     DEFINE_PROP_BOOL("kvm", X86CPU, expose_kvm, true),
+     DEFINE_PROP_UINT32("phys-bits", X86CPU, phys_bits, 0),
+     DEFINE_PROP_BOOL("host-phys-bits", X86CPU, host_phys_bits, false),
+diff --git a/target/i386/cpu.h b/target/i386/cpu.h
+index 8720b761c..684c4cfc8 100644
+--- a/target/i386/cpu.h
++++ b/target/i386/cpu.h
+@@ -1751,6 +1751,13 @@ struct X86CPU {
+      * compatibility.
+      */
+     bool force_features;
++    /*
++     * Preserve the legacy AMD SPEC_CTRL guest ABI when KVM provides the
++     * IA32_SPEC_CTRL MSR but no longer advertises CPUID.7.0:EDX[26]. This is
++     * enabled by default in the VEXXHOST downstream build and may be disabled
++     * with x-amd-legacy-spec-ctrl=off.
++     */
++    bool amd_legacy_spec_ctrl;
+     bool expose_kvm;
+     bool expose_tcg;
+     bool migratable;
+diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
+index 5a698bde1..263d4eeee 100644
+--- a/target/i386/kvm/kvm.c
++++ b/target/i386/kvm/kvm.c
+@@ -162,6 +162,11 @@ bool kvm_has_exception_payload(void)
+     return has_exception_payload;
+ }
+ 
++bool kvm_supports_spec_ctrl_msr(void)
++{
++    return has_msr_spec_ctrl;
++}
++
+ static bool kvm_x2apic_api_set_flags(uint64_t flags)
+ {
+     KVMState *s = KVM_STATE(current_accel());
+diff --git a/target/i386/kvm/kvm_i386.h b/target/i386/kvm/kvm_i386.h
+index a978509d5..6eb52b559 100644
+--- a/target/i386/kvm/kvm_i386.h
++++ b/target/i386/kvm/kvm_i386.h
+@@ -45,6 +45,7 @@ void kvm_put_apicbase(X86CPU *cpu, uint64_t value);
+ bool kvm_enable_x2apic(void);
+ bool kvm_has_x2apic_api(void);
+ bool kvm_has_waitpkg(void);
++bool kvm_supports_spec_ctrl_msr(void);
+ 
+ bool kvm_hv_vpindex_settable(void);
+ bool kvm_hyperv_expand_features(X86CPU *cpu, Error **errp);
+diff --git a/tests/avocado/x86_amd_legacy_spec_ctrl.py b/tests/avocado/x86_amd_legacy_spec_ctrl.py
+new file mode 100644
+index 000000000..bc03c940c
+--- /dev/null
++++ b/tests/avocado/x86_amd_legacy_spec_ctrl.py
+@@ -0,0 +1,71 @@
++# Validate AMD legacy SPEC_CTRL live-migration compatibility.
++#
++# Copyright (c) 2026 VEXXHOST, Inc.
++#
++# This work is licensed under the terms of the GNU GPL, version 2 or
++# later. See the COPYING file in the top-level directory.
++
++from avocado import skipUnless
++from avocado_qemu import QemuSystemTest
++
++
++class X86CPUFeatureReporting(QemuSystemTest):
++    """:avocado: tags=arch:x86_64"""
++
++    @staticmethod
++    def feature_word(words, eax, ecx, register):
++        for word in words:
++            if (word['cpuid-input-eax'] == eax and
++                    word.get('cpuid-input-ecx', 0) == ecx and
++                    word['cpuid-register'] == register):
++                return word['features']
++        return 0
++
++    def cpu_features(self):
++        cpu_path = self.vm.cmd('query-cpus-fast')[0]['qom-path']
++        present = self.vm.cmd('qom-get', path=cpu_path,
++                              property='feature-words')
++        filtered = self.vm.cmd('qom-get', path=cpu_path,
++                               property='filtered-features')
++        return present, filtered
++
++    def test_force_features_semantics_unchanged(self):
++        """Generic x-force-features still reports unsupported features."""
++        hle_bit = 1 << 4
++
++        self.require_accelerator('tcg')
++        self.vm.add_args('-S', '-accel', 'tcg')
++        self.set_vm_arg('-cpu',
++                        'EPYC-Rome,hle=on,x-force-features=on')
++        self.vm.launch()
++        present, filtered = self.cpu_features()
++
++        self.assertEqual(self.feature_word(present, 7, 0, 'EBX') & hle_bit,
++                         hle_bit)
++        self.assertEqual(self.feature_word(filtered, 7, 0, 'EBX') & hle_bit,
++                         hle_bit)
++
++    @skipUnless('AuthenticAMD' in open('/proc/cpuinfo').read(),
++                'requires an AMD KVM host')
++    def test_amd_legacy_spec_ctrl(self):
++        """The scoped property preserves only AMD SPEC_CTRL reporting.
++
++        :avocado: tags=accel:kvm
++        """
++        spec_ctrl_bit = 1 << 26
++
++        self.require_accelerator('kvm')
++        self.vm.add_args('-S', '-accel', 'kvm')
++        self.set_vm_arg('-cpu', 'EPYC-Rome,spec-ctrl=on')
++        self.vm.launch()
++        cpu_path = self.vm.cmd('query-cpus-fast')[0]['qom-path']
++        self.assertTrue(self.vm.cmd('qom-get', path=cpu_path,
++                                    property='x-amd-legacy-spec-ctrl'))
++        present, filtered = self.cpu_features()
++
++        self.assertEqual(
++            self.feature_word(present, 7, 0, 'EDX') & spec_ctrl_bit,
++            spec_ctrl_bit)
++        self.assertEqual(
++            self.feature_word(filtered, 7, 0, 'EDX') & spec_ctrl_bit,
++            0)

--- a/patches/qemu/series
+++ b/patches/qemu/series
@@ -1,0 +1,1 @@
+amd-legacy-spec-ctrl.patch


### PR DESCRIPTION
## Summary

Backport of #313 for the Jammy-based `stable/zed` image.

- rebuild Ubuntu Jammy's native QEMU `1:6.2+dfsg-2ubuntu6.31`
- apply the narrow AMD/KVM legacy `spec-ctrl` compatibility behavior
- preserve requested `spec-ctrl` only when KVM exposes `IA32_SPEC_CTRL`
- retain Ubuntu package integration and machine types
- keep generated `.deb` archives out of final image layers
- leave the arm64 image unchanged

## Backport adaptation

This does not reuse the Noble source pin. It is rebased onto Ubuntu's exact Jammy QEMU source import at `004a3f40281fbcb896ab96c57359267128140251`, after its native Quilt series.

## Validation

- downstream patch applies after the Jammy Quilt stack with `--fuzz=0`
- shell syntax passes
- Dockerfile build checks pass without warnings
- full multi-architecture image CI will validate native package and image builds
