### PR TITLE
Install matching QEMU RBD module package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG FROM=ghcr.io/vexxhost/ubuntu-cloud-archive:main@sha256:8ecef42d4bdd95bafa380
 FROM ${FROM} AS qemu-builder
 ARG TARGETARCH
 ARG QEMU_COMMIT=c509d34e5d97b1949b8daafbb53afdd036c2195d
-ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost1
+ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost2
 RUN if [ "${TARGETARCH}" = amd64 ]; then \
         apt-get update && \
         apt-get install --no-install-recommends -y \
@@ -40,7 +40,7 @@ RUN --network=none if [ "${TARGETARCH}" = amd64 ]; then \
 
 FROM ${FROM}
 ARG TARGETARCH
-ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost1
+ARG QEMU_PACKAGE_VERSION=1:8.2.2+ds-0ubuntu1.18+vexxhost2
 RUN groupadd -g 42424 nova && \
     useradd -u 42424 -g 42424 -M -d /var/lib/nova -s /usr/sbin/nologin -c "Nova User" nova && \
     mkdir -p /etc/nova /var/log/nova /var/lib/nova /var/cache/nova && \
@@ -74,7 +74,15 @@ RUN --mount=type=bind,from=qemu-builder,source=/out,target=/qemu-debs,ro \
         swtpm-tools \
         ${QEMU_DEBS} && \
     if [ "${TARGETARCH}" = amd64 ]; then \
-        test "$(dpkg-query -W -f='${Version}' qemu-system-x86)" = "${QEMU_PACKAGE_VERSION}"; \
+        test "$(dpkg-query -W -f='${Version}' qemu-block-extra)" = "${QEMU_PACKAGE_VERSION}" && \
+        test "$(dpkg-query -W -f='${Version}' qemu-system-common)" = "${QEMU_PACKAGE_VERSION}" && \
+        test "$(dpkg-query -W -f='${Version}' qemu-system-x86)" = "${QEMU_PACKAGE_VERSION}" && \
+        RBD_PROBE_OUTPUT="$(timeout 5 qemu-system-x86_64 -display none -nodefaults \
+            -blockdev '{"driver":"rbd","pool":"__probe__","image":"__probe__","server":[{"host":"127.0.0.1","port":"1"}],"node-name":"rbd-probe"}' 2>&1 || true)" && \
+        if printf '%s\n' "${RBD_PROBE_OUTPUT}" | grep -Eq "Unable to load block driver rbd|Unknown driver 'rbd'"; then \
+            printf '%s\n' "${RBD_PROBE_OUTPUT}" >&2; \
+            exit 1; \
+        fi; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/hack/build-qemu
+++ b/hack/build-qemu
@@ -28,8 +28,9 @@ dpkg-buildpackage --build=any --unsigned-source --unsigned-changes -jauto
 
 mkdir -p /out
 find .. -maxdepth 1 -type f \
-    \( -name 'qemu-system-common_*_*.deb' -o \
+    \( -name 'qemu-block-extra_*_*.deb' -o \
+       -name 'qemu-system-common_*_*.deb' -o \
        -name 'qemu-system-x86_*_*.deb' \) \
     -exec cp -v '{}' /out/ ';'
 
-test "$(find /out -maxdepth 1 -type f -name '*.deb' | wc -l)" -eq 2
+test "$(find /out -maxdepth 1 -type f -name '*.deb' | wc -l)" -eq 3


### PR DESCRIPTION
## Summary

- export `qemu-block-extra` from the same native QEMU build as `qemu-system-common` and `qemu-system-x86`
- install all three matching downstream packages in the runtime image
- bump the downstream package release from `+vexxhost1` to `+vexxhost2`
- verify all three installed package versions
- probe QEMU's `rbd` block driver during the image build and fail on `Unknown driver`/module-load errors

## Root cause

The previous image rebuilt only QEMU core packages while retaining Ubuntu's stock `qemu-block-extra`. The resulting QEMU could not load `block-rbd.so`, and boot-from-volume guests failed with:

```text
Unable to load block driver rbd
Unknown driver 'rbd'
```

Existing running guests were unaffected, but stopped Cinder-backed guests could not start.

## Validation

- `git diff --check`
- `bash -n hack/build-qemu`
- image build contains an RBD runtime probe
